### PR TITLE
Update resourceset.js by removing extra "/"

### DIFF
--- a/resources/resourceset.js
+++ b/resources/resourceset.js
@@ -40,7 +40,7 @@ function ResourceSet(resourcemboset,cookie,maxfactory,mbo)
  	if(maxfactory != "undefined" && mbo != "undefined")
  	{
 		X_PUB_PATH = maxfactory.auth_scheme + '/oslc/';
-		REST_PATH = X_PUB_PATH + '/os/';
+		REST_PATH = X_PUB_PATH + 'os/';
 
 	 	this.maximoRestUrl = maxfactory.resturl;
 	 	this.password = maxfactory.password;


### PR DESCRIPTION
It seems all sources of X_PUB_PATH ends with "/". So I'd suggest to remove the extra "/" before "os" for REST_PATH variable:
REST_PATH = X_PUB_PATH + 'os/';
The extra "/" makes the oslc request to fail for TPAE OSLC versions higher than 7.6:
/maximo_b1dk/oslc//os/MXWODETAIL?lean=1&oslc.select=wonum%2Cdescription%......